### PR TITLE
Analytic QMHL test

### DIFF
--- a/qhbmlib/qmhl.py
+++ b/qhbmlib/qmhl.py
@@ -37,6 +37,7 @@ def qmhl(model, target_circuits, target_counts):
   @tf.custom_gradient
   def loss(unused):
     # log_partition estimate
+
     if model.ebm.is_analytic:
       log_partition = model.log_partition_function()
     else:


### PR DESCRIPTION
Add test comparing QMHL loss and loss derivatives to analytically derived quantities.

The test QHBM is a tensor product of Bernoullis acted on with single qubit X rotations.  The target data state is a different tensor product of Bernoullis, rotated by single qubit Y gates.  See the QMHL section of [this colab notebook](https://colab.research.google.com/drive/14987JCMju_8AVvvVoojwe6hA7Nlw-Dhe?usp=sharing) for derivations of the expected quantities.

Since the gradients are tested with `tf.GradientTape`, this resolves #51.