### PR TITLE
Remove lint from energy files

### DIFF
--- a/qhbmlib/energy_model.py
+++ b/qhbmlib/energy_model.py
@@ -1,4 +1,3 @@
-# pylint: skip-file
 # Copyright 2021 The QHBM Library Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -106,7 +105,7 @@ class PauliMixin(abc.ABC):
 
     Args:
       qubits: List of cirq.GridQubits. objects to measure.
-    
+
     Returns:
       List of PauliSum objects whose expectation values are fed to
         `operator_expectation` to compute average energy.

--- a/qhbmlib/energy_model_utils.py
+++ b/qhbmlib/energy_model_utils.py
@@ -1,4 +1,3 @@
-# pylint: skip-file
 # Copyright 2021 The QHBM Library Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/energy_infer_test.py
+++ b/tests/energy_infer_test.py
@@ -1,4 +1,3 @@
-# pylint: skip-file
 # Copyright 2021 The QHBM Library Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -160,7 +159,7 @@ class AnalyticInferenceLayerTest(tf.test.TestCase):
     one_bit_energy = energy_model.KOBE([0], 1,
                                        tf.keras.initializers.Constant(0.0))
     actual_layer = energy_infer.AnalyticInferenceLayer(one_bit_energy)
-    self.assertIsNone(actual_layer._current_dist)
+    self.assertIsNone(actual_layer.current_dist)
     actual_dist = actual_layer(None)
     self.assertIsInstance(actual_dist, tfp.distributions.Categorical)
 
@@ -305,7 +304,7 @@ class BernoulliInferenceLayerTest(tf.test.TestCase):
                                           tf.keras.initializers.Constant(0.0))
     actual_layer = energy_infer.BernoulliInferenceLayer(energy)
     actual_layer.build([])
-    self.assertIsNone(actual_layer._current_dist)
+    self.assertIsNone(actual_layer.current_dist)
     actual_dist = actual_layer(None)
     self.assertIsInstance(actual_dist, tfp.distributions.Bernoulli)
 

--- a/tests/energy_model_test.py
+++ b/tests/energy_model_test.py
@@ -1,4 +1,3 @@
-# pylint: skip-file
 # Copyright 2021 The QHBM Library Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -86,8 +85,8 @@ class BitstringEnergyTest(tf.test.TestCase):
       expected_mlp.set_weights(actual_mlp.get_weights())
 
       @tf.function
-      def special_energy(bitstrings):
-        return actual_mlp(bitstrings)
+      def special_energy(bitstrings, mlp=actual_mlp):
+        return mlp(bitstrings)
 
       for e_func in [actual_mlp, special_energy]:
         with tf.GradientTape(persistent=True) as tape:
@@ -155,14 +154,14 @@ class BernoulliEnergyTest(tf.test.TestCase):
     num_tests = 5
     for _ in range(num_tests):
       bits = random.sample(range(1000), num_bits)
-      thetas = tf.random.uniform([num_bits], minval=-100, maxval=100)
+      thetas = tf.random.uniform([num_bits], -100, 100, tf.float32)
       test_b = energy_model.BernoulliEnergy(bits)
       test_b.build([None, num_bits])
       test_b.set_weights([thetas])
 
       @tf.function
-      def special_energy(bitstrings):
-        return test_b(bitstrings)
+      def special_energy(bitstrings, bernoulli=test_b):
+        return bernoulli(bitstrings)
 
       for e_func in [test_b, special_energy]:
         with tf.GradientTape() as tape:

--- a/tests/energy_model_utils_test.py
+++ b/tests/energy_model_utils_test.py
@@ -1,4 +1,3 @@
-# pylint: skip-file
 # Copyright 2021 The QHBM Library Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Remove lint from energy files.

Part of #120.  Removes the `pylint: skip-file` flag from all the `energy_*` module and test files.