### PR TITLE
Approximate derivative utilities

### DIFF
--- a/tests/inference/ebm_test.py
+++ b/tests/inference/ebm_test.py
@@ -463,7 +463,8 @@ class AnalyticEnergyInferenceTest(tf.test.TestCase):
         expected_expectation)
     self.assertAllClose(actual_expectation, expected_expectation)
 
-    expected_gradient = test_util.approximate_gradient(expectation_func, energy_var)
+    expected_gradient = test_util.approximate_gradient(expectation_func,
+                                                       energy_var)
     tf.nest.map_structure(
         lambda x: self.assertAllGreater(tf.abs(x), self.not_zero_atol),
         expected_derivative)
@@ -497,7 +498,8 @@ class AnalyticEnergyInferenceTest(tf.test.TestCase):
 
     actual_log_partition_grad = tape.gradient(actual_log_partition,
                                               actual_energy.trainable_variables)
-    expected_log_partition_grad = test_util.approximate_gradient(exact_log_partition, actual_energy.trainable_variables)
+    expected_log_partition_grad = test_util.approximate_gradient(
+        exact_log_partition, actual_energy.trainable_variables)
     self.assertAllClose(actual_log_partition_grad, expected_log_partition_grad,
                         self.close_rtol)
 
@@ -679,7 +681,8 @@ class BernoulliEnergyInferenceTest(tf.test.TestCase):
 
     actual_log_partition_grad = tape.gradient(actual_log_partition,
                                               actual_energy.trainable_variables)
-    expected_log_partition_grad(exact_log_partition, actual_energy.trainable_variables)
+    expected_log_partition_grad(exact_log_partition,
+                                actual_energy.trainable_variables)
     self.assertAllClose(actual_log_partition_grad, expected_log_partition_grad,
                         self.close_rtol)
 

--- a/tests/inference/ebm_test.py
+++ b/tests/inference/ebm_test.py
@@ -412,7 +412,7 @@ class AnalyticEnergyInferenceTest(tf.test.TestCase):
         actual_average, mu, unconnected_gradients=tf.UnconnectedGradients.ZERO)
     self.assertAllLess(tf.math.abs(actual_gradient_mu), self.zero_atol)
 
-  @test_util.toggle_eager_mode
+  @test_util.eager_mode_toggle
   def test_expectation_finite_difference(self):
     """Tests a function with nested structural output."""
 
@@ -467,7 +467,7 @@ class AnalyticEnergyInferenceTest(tf.test.TestCase):
                                                        energy_var)
     tf.nest.map_structure(
         lambda x: self.assertAllGreater(tf.abs(x), self.not_zero_atol),
-        expected_derivative)
+        expected_gradient)
     self.assertAllClose(
         actual_gradient, expected_gradient, rtol=self.close_rtol)
 
@@ -681,8 +681,8 @@ class BernoulliEnergyInferenceTest(tf.test.TestCase):
 
     actual_log_partition_grad = tape.gradient(actual_log_partition,
                                               actual_energy.trainable_variables)
-    expected_log_partition_grad(exact_log_partition,
-                                actual_energy.trainable_variables)
+    expected_log_partition_grad = test_util.approximate_gradient(
+        exact_log_partition, actual_energy.trainable_variables)
     self.assertAllClose(actual_log_partition_grad, expected_log_partition_grad,
                         self.close_rtol)
 

--- a/tests/inference/qmhl_loss_test.py
+++ b/tests/inference/qmhl_loss_test.py
@@ -121,7 +121,9 @@ class QMHLTest(tf.test.TestCase):
       actual_derivative = tape.gradient(actual_loss,
                                         model_h.trainable_variables)
 
-      expected_derivative = test_util.approximate_gradient(functools.partial(qmhl_wrapper, actual_data, model_qhbm), model_h.trainable_variables)
+      expected_derivative = test_util.approximate_gradient(
+          functools.partial(qmhl_wrapper, actual_data, model_qhbm),
+          model_h.trainable_variables)
 
       # Changing model parameters is working if finite difference derivatives
       # are non-zero.  Also confirms that model_h and data_h are different.

--- a/tests/inference/qmhl_loss_test.py
+++ b/tests/inference/qmhl_loss_test.py
@@ -95,19 +95,6 @@ class QMHLTest(tf.test.TestCase):
 
     qmhl_wrapper = tf.function(inference.qmhl)
 
-    def qmhl_derivative(variables_list, actual_data, model_qhbm):
-      """Approximately differentiates QMHL wih respect to the inputs."""
-      derivatives = []
-      for var in variables_list:
-        var_derivative_list = []
-        num_elts = tf.size(var)  # Assumes variable is 1D
-        for n in range(num_elts):
-          this_derivative = test_util.approximate_derivative(
-              functools.partial(delta_qmhl, n, var, actual_data, model_qhbm))
-          var_derivative_list.append(this_derivative.numpy())
-        derivatives.append(tf.constant(var_derivative_list))
-      return derivatives
-
     for num_qubits in self.num_qubits_list:
       qubits = cirq.GridQubit.rect(1, num_qubits)
       num_layers = 2
@@ -134,8 +121,8 @@ class QMHLTest(tf.test.TestCase):
       actual_derivative = tape.gradient(actual_loss,
                                         model_h.trainable_variables)
 
-      expected_derivative = qmhl_derivative(model_h.trainable_variables,
-                                            actual_data, model_qhbm)
+      expected_derivative = test_util.approximate_gradient(functools.partial(qmhl_wrapper, actual_data, model_qhbm), model_h.trainable_variables)
+
       # Changing model parameters is working if finite difference derivatives
       # are non-zero.  Also confirms that model_h and data_h are different.
       tf.nest.map_structure(

--- a/tests/inference/qnn_test.py
+++ b/tests/inference/qnn_test.py
@@ -250,9 +250,7 @@ class QuantumInferenceTest(parameterized.TestCase, tf.test.TestCase):
         tf.zeros_like(expected_jacobian),
         atol=self.not_zero_atol)
     self.assertAllClose(
-        expected_jacobian,
-        actual_jacobian,
-        atol=self.close_atol)
+        expected_jacobian, actual_jacobian, atol=self.close_atol)
 
   @parameterized.parameters({
       "energy_class": energy_class,
@@ -517,7 +515,8 @@ class QuantumInferenceTest(parameterized.TestCase, tf.test.TestCase):
         tf.shape(actual_expectations), [len(initial_states_list), 1])
 
     expected_derivatives = test_util.approximate_jacobian(
-        functools.partial(expectation_wrapper, initial_states, hamiltonian), hamiltonian.trainable_variables)
+        functools.partial(expectation_wrapper, initial_states, hamiltonian),
+        hamiltonian.trainable_variables)
     for derivative in expected_derivatives:
       # Checks that at last one entry in each variable's derivative is
       # not too close to zero.

--- a/tests/inference/qnn_test.py
+++ b/tests/inference/qnn_test.py
@@ -246,12 +246,12 @@ class QuantumInferenceTest(parameterized.TestCase, tf.test.TestCase):
         expectation_func, actual_circuit.trainable_variables)
 
     self.assertNotAllClose(
-        expected_expectations_derivative,
-        tf.zeros_like(expected_expectations_derivative),
+        expected_jacobian,
+        tf.zeros_like(expected_jacobian),
         atol=self.not_zero_atol)
     self.assertAllClose(
-        expected_expectations_derivative,
-        actual_expectations_derivative,
+        expected_jacobian,
+        actual_jacobian,
         atol=self.close_atol)
 
   @parameterized.parameters({
@@ -517,7 +517,7 @@ class QuantumInferenceTest(parameterized.TestCase, tf.test.TestCase):
         tf.shape(actual_expectations), [len(initial_states_list), 1])
 
     expected_derivatives = test_util.approximate_jacobian(
-        expectation_wrapper, hamiltonian.trainable_variables)
+        functools.partial(expectation_wrapper, initial_states, hamiltonian), hamiltonian.trainable_variables)
     for derivative in expected_derivatives:
       # Checks that at last one entry in each variable's derivative is
       # not too close to zero.

--- a/tests/inference/qnn_test.py
+++ b/tests/inference/qnn_test.py
@@ -240,24 +240,8 @@ class QuantumInferenceTest(parameterized.TestCase, tf.test.TestCase):
     self.assertAllClose(
         actual_expectations, expected_expectations, rtol=self.close_rtol)
 
-    def expectations_derivative(variables_list):
-      """Approximately differentiates expectations with respect to the inputs"""
-      derivatives = []
-      for var in variables_list:
-        var_derivative_list = []
-        num_elts = tf.size(var)  # Assumes variable is 1D
-        for n in range(num_elts):
-          this_derivative = test_util.approximate_derivative_unsummed(
-              functools.partial(test_util.perturb_function, expectation_func,
-                                var, n))
-          var_derivative_list.append(this_derivative.numpy())
-        derivatives.append(tf.constant(var_derivative_list))
-      return derivatives
-
-    expected_expectations_derivative = tf.transpose(
-        tf.squeeze(expectations_derivative(actual_circuit.trainable_variables)))
-    actual_expectations_derivative = tf.squeeze(
-        tape.jacobian(actual_expectations, actual_circuit.trainable_variables))
+    actual_jacobian = tape.jacobian(actual_expectations, actual_circuit.trainable_variables)
+    expected_jacobian = test_util.approximate_jacobian(expectation_wrapper, actual_circuit.trainable_variables)
 
     self.assertNotAllClose(
         expected_expectations_derivative,
@@ -348,48 +332,26 @@ class QuantumInferenceTest(parameterized.TestCase, tf.test.TestCase):
                                                 hamiltonian_measure)
     self.assertAllClose(actual_expectations, expected_expectations)
 
-    def expectations_derivative(variables_list):
-      """Approximately differentiates expectations with respect to the inputs"""
-      derivatives = []
-      for var in variables_list:
-        var_derivative_list = []
-        num_elts = tf.size(var)  # Assumes variable is 1D
-        for n in range(num_elts):
-          this_derivative = test_util.approximate_derivative_unsummed(
-              functools.partial(test_util.perturb_function, expectation_func,
-                                var, n))
-          var_derivative_list.append(this_derivative.numpy())
-        derivatives.append(tf.constant(var_derivative_list))
-      return derivatives
-
-    expected_derivatives_thetas = tf.transpose(
-        tf.squeeze(
-            expectations_derivative(
-                hamiltonian_measure.energy.trainable_variables)))
+    expected_jacobian_thetas = test_util.approximate_jacobian(expectation_func, hamiltonian_measure.energy.trainable_variables)
     self.assertNotAllClose(
         expected_derivatives_thetas,
         tf.zeros_like(expected_derivatives_thetas),
         atol=self.not_zero_atol)
-    expected_derivatives_phis = tf.transpose(
-        tf.squeeze(
-            expectations_derivative(
-                hamiltonian_measure.circuit.trainable_variables)))
+    expected_jacobian_phis = test_util.approximate_jacobian(expectation_func, hamiltonian_measure.circuit.trainable_variables)
     self.assertNotAllClose(
         expected_derivatives_phis,
         tf.zeros_like(expected_derivatives_phis),
         atol=self.not_zero_atol)
-    actual_derivatives_thetas, actual_derivatives_phis = tape.jacobian(
+    actual_jacobian_thetas, actual_jacobian_phis = tape.jacobian(
         actual_expectations, (hamiltonian_measure.energy.trainable_variables,
                               hamiltonian_measure.circuit.trainable_variables))
-    actual_derivatives_thetas = tf.squeeze(actual_derivatives_thetas)
-    actual_derivatives_phis = tf.squeeze(actual_derivatives_phis)
     self.assertAllClose(
-        actual_derivatives_phis,
-        expected_derivatives_phis,
+        actual_jacobian_phis,
+        expected_jacobian_phis,
         rtol=self.close_rtol)
     self.assertAllClose(
-        actual_derivatives_thetas,
-        expected_derivatives_thetas,
+        actual_jacobian_thetas,
+        expected_jacobian_thetas,
         rtol=self.close_rtol)
 
   @test_util.eager_mode_toggle
@@ -558,34 +520,7 @@ class QuantumInferenceTest(parameterized.TestCase, tf.test.TestCase):
       """Returns the current expectation values."""
       return tf.squeeze(actual_qnn.expectation(initial_states, hamiltonian), -1)
 
-    delta = 1e-1
-
-    # TODO(#206)
-    def expectations_derivative(variables_list):
-      """Approximately differentiates expectations with respect to the inputs"""
-      derivatives = []
-      for var in variables_list:
-        per_bitstring_derivative_list = []
-        num_elts = tf.size(var)
-        for n in range(num_elts):
-          this_derivative = test_util.approximate_derivative_unsummed(
-              functools.partial(test_util.perturb_function, expectation_func,
-                                var, n),
-              delta=delta)
-          per_bitstring_derivative_list.append(this_derivative)
-        # shape is now [num_elts, len(initial_states_list)]
-        var_derivatives = tf.stack(per_bitstring_derivative_list)
-        # transpose to shape [len(initial_states_list), num_elts]
-        var_derivatives_transpose = tf.transpose(var_derivatives)
-        # reshape the trailing dimensions to match the original variable
-        derivatives.append(
-            tf.reshape(var_derivatives_transpose,
-                       [len(initial_states_list), 1] +
-                       tf.shape(var).numpy().tolist()))
-      return derivatives
-
-    expected_derivatives = expectations_derivative(
-        hamiltonian.trainable_variables)
+    expected_derivatives = test_util.approximate_jacobian(expectation_func, hamiltonian.trainable_variables)
     for derivative in expected_derivatives:
       # Checks that at last one entry in each variable's derivative is
       # not too close to zero.

--- a/tests/inference/qnn_test.py
+++ b/tests/inference/qnn_test.py
@@ -243,7 +243,7 @@ class QuantumInferenceTest(parameterized.TestCase, tf.test.TestCase):
     actual_jacobian = tape.jacobian(actual_expectations,
                                     actual_circuit.trainable_variables)
     expected_jacobian = test_util.approximate_jacobian(
-        expectation_wrapper, actual_circuit.trainable_variables)
+        expectation_func, actual_circuit.trainable_variables)
 
     self.assertNotAllClose(
         expected_expectations_derivative,
@@ -337,14 +337,14 @@ class QuantumInferenceTest(parameterized.TestCase, tf.test.TestCase):
     expected_jacobian_thetas = test_util.approximate_jacobian(
         expectation_func, hamiltonian_measure.energy.trainable_variables)
     self.assertNotAllClose(
-        expected_derivatives_thetas,
-        tf.zeros_like(expected_derivatives_thetas),
+        expected_jacobian_thetas,
+        tf.zeros_like(expected_jacobian_thetas),
         atol=self.not_zero_atol)
     expected_jacobian_phis = test_util.approximate_jacobian(
         expectation_func, hamiltonian_measure.circuit.trainable_variables)
     self.assertNotAllClose(
-        expected_derivatives_phis,
-        tf.zeros_like(expected_derivatives_phis),
+        expected_jacobian_phis,
+        tf.zeros_like(expected_jacobian_phis),
         atol=self.not_zero_atol)
     actual_jacobian_thetas, actual_jacobian_phis = tape.jacobian(
         actual_expectations, (hamiltonian_measure.energy.trainable_variables,
@@ -516,12 +516,8 @@ class QuantumInferenceTest(parameterized.TestCase, tf.test.TestCase):
     self.assertAllEqual(
         tf.shape(actual_expectations), [len(initial_states_list), 1])
 
-    def expectation_func():
-      """Returns the current expectation values."""
-      return tf.squeeze(actual_qnn.expectation(initial_states, hamiltonian), -1)
-
     expected_derivatives = test_util.approximate_jacobian(
-        expectation_func, hamiltonian.trainable_variables)
+        expectation_wrapper, hamiltonian.trainable_variables)
     for derivative in expected_derivatives:
       # Checks that at last one entry in each variable's derivative is
       # not too close to zero.

--- a/tests/inference/qnn_test.py
+++ b/tests/inference/qnn_test.py
@@ -240,8 +240,10 @@ class QuantumInferenceTest(parameterized.TestCase, tf.test.TestCase):
     self.assertAllClose(
         actual_expectations, expected_expectations, rtol=self.close_rtol)
 
-    actual_jacobian = tape.jacobian(actual_expectations, actual_circuit.trainable_variables)
-    expected_jacobian = test_util.approximate_jacobian(expectation_wrapper, actual_circuit.trainable_variables)
+    actual_jacobian = tape.jacobian(actual_expectations,
+                                    actual_circuit.trainable_variables)
+    expected_jacobian = test_util.approximate_jacobian(
+        expectation_wrapper, actual_circuit.trainable_variables)
 
     self.assertNotAllClose(
         expected_expectations_derivative,
@@ -332,12 +334,14 @@ class QuantumInferenceTest(parameterized.TestCase, tf.test.TestCase):
                                                 hamiltonian_measure)
     self.assertAllClose(actual_expectations, expected_expectations)
 
-    expected_jacobian_thetas = test_util.approximate_jacobian(expectation_func, hamiltonian_measure.energy.trainable_variables)
+    expected_jacobian_thetas = test_util.approximate_jacobian(
+        expectation_func, hamiltonian_measure.energy.trainable_variables)
     self.assertNotAllClose(
         expected_derivatives_thetas,
         tf.zeros_like(expected_derivatives_thetas),
         atol=self.not_zero_atol)
-    expected_jacobian_phis = test_util.approximate_jacobian(expectation_func, hamiltonian_measure.circuit.trainable_variables)
+    expected_jacobian_phis = test_util.approximate_jacobian(
+        expectation_func, hamiltonian_measure.circuit.trainable_variables)
     self.assertNotAllClose(
         expected_derivatives_phis,
         tf.zeros_like(expected_derivatives_phis),
@@ -346,13 +350,9 @@ class QuantumInferenceTest(parameterized.TestCase, tf.test.TestCase):
         actual_expectations, (hamiltonian_measure.energy.trainable_variables,
                               hamiltonian_measure.circuit.trainable_variables))
     self.assertAllClose(
-        actual_jacobian_phis,
-        expected_jacobian_phis,
-        rtol=self.close_rtol)
+        actual_jacobian_phis, expected_jacobian_phis, rtol=self.close_rtol)
     self.assertAllClose(
-        actual_jacobian_thetas,
-        expected_jacobian_thetas,
-        rtol=self.close_rtol)
+        actual_jacobian_thetas, expected_jacobian_thetas, rtol=self.close_rtol)
 
   @test_util.eager_mode_toggle
   def test_expectation_bitstring_energy(self):
@@ -520,7 +520,8 @@ class QuantumInferenceTest(parameterized.TestCase, tf.test.TestCase):
       """Returns the current expectation values."""
       return tf.squeeze(actual_qnn.expectation(initial_states, hamiltonian), -1)
 
-    expected_derivatives = test_util.approximate_jacobian(expectation_func, hamiltonian.trainable_variables)
+    expected_derivatives = test_util.approximate_jacobian(
+        expectation_func, hamiltonian.trainable_variables)
     for derivative in expected_derivatives:
       # Checks that at last one entry in each variable's derivative is
       # not too close to zero.

--- a/tests/inference/vqt_loss_test.py
+++ b/tests/inference/vqt_loss_test.py
@@ -113,7 +113,7 @@ class VQTTest(tf.test.TestCase):
           actual_loss,
           (model_h.trainable_variables, data_h.trainable_variables))
 
-      expected_gradient_model, expected_gradient_date = test_util.approximate_gradient(
+      expected_gradient_model, expected_gradient_data = test_util.approximate_gradient(
           functools.partial(vqt_wrapper, model_infer, data_h, beta),
           (model_h.trainable_variables, data_h.trainable_variables))
       # Changing model parameters is working if finite difference derivatives

--- a/tests/inference/vqt_loss_test.py
+++ b/tests/inference/vqt_loss_test.py
@@ -127,8 +127,10 @@ class VQTTest(tf.test.TestCase):
           actual_loss,
           (model_h.trainable_variables, data_h.trainable_variables))
 
-      expected_derivative_model = test_util.approximate_gradient(vqt_wrapper, model_h.trainable_variables)
-      expected_derivative_data = test_util.approximate_gradient(vqt_wrapper, data_h.trainable_variables)
+      expected_derivative_model = test_util.approximate_gradient(
+          vqt_wrapper, model_h.trainable_variables)
+      expected_derivative_data = test_util.approximate_gradient(
+          vqt_wrapper, data_h.trainable_variables)
       # Changing model parameters is working if finite difference derivatives
       # are non-zero.  Also confirms that model_h and data_h are different.
       tf.nest.map_structure(

--- a/tests/inference/vqt_loss_test.py
+++ b/tests/inference/vqt_loss_test.py
@@ -114,7 +114,7 @@ class VQTTest(tf.test.TestCase):
           (model_h.trainable_variables, data_h.trainable_variables))
 
       expected_gradient_model, expected_gradient_date = test_util.approximate_gradient(
-          functools.partial(vqt_wrapper, mode_infer, data_h, beta),
+          functools.partial(vqt_wrapper, model_infer, data_h, beta),
           (model_h.trainable_variables, data_h.trainable_variables))
       # Changing model parameters is working if finite difference derivatives
       # are non-zero.  Also confirms that model_h and data_h are different.

--- a/tests/inference/vqt_loss_test.py
+++ b/tests/inference/vqt_loss_test.py
@@ -114,7 +114,8 @@ class VQTTest(tf.test.TestCase):
           (model_h.trainable_variables, data_h.trainable_variables))
 
       expected_gradient_model, expected_gradient_date = test_util.approximate_gradient(
-          functools.partiial(vqt_wrapper, mode_infer, data_h, beta), (model_h.trainable_variables, data_h.trainable_variables))
+          functools.partial(vqt_wrapper, mode_infer, data_h, beta),
+          (model_h.trainable_variables, data_h.trainable_variables))
       # Changing model parameters is working if finite difference derivatives
       # are non-zero.  Also confirms that model_h and data_h are different.
       tf.nest.map_structure(
@@ -124,13 +125,9 @@ class VQTTest(tf.test.TestCase):
           lambda x: self.assertAllGreater(tf.abs(x), self.not_zero_atol),
           expected_gradient_data)
       self.assertAllClose(
-          actual_gradient_model,
-          expected_gradient_model,
-          rtol=self.close_rtol)
+          actual_gradient_model, expected_gradient_model, rtol=self.close_rtol)
       self.assertAllClose(
-          actual_gradient_data,
-          expected_gradient_data,
-          rtol=self.close_rtol)
+          actual_gradient_data, expected_gradient_data, rtol=self.close_rtol)
 
   @test_util.eager_mode_toggle
   def test_loss_value_x_rot(self):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -308,16 +308,18 @@ def approximate_jacobian(f, variables, delta=5e-2):
     derivatives_list = []
     num_elts = tf.size(var)
     for i in range(num_elts):
-      forward_twice = perturb_func(f, var, i, 2.0 * delta)
-      forward_once = perturb_func(f, var, i, delta)
-      backward_once = perturb_func(f, var, i, -1.0 * delta)
-      backward_twice = perturb_func(f, var, i, -2.0 * delta)
+      forward_twice = perturb_function(f, var, i, 2.0 * delta)
+      forward_once = perturb_function(f, var, i, delta)
+      backward_once = perturb_function(f, var, i, -1.0 * delta)
+      backward_twice = perturb_function(f, var, i, -2.0 * delta)
       numerator = (-1.0 * forward_twice + 8.0 * forward_once - 8.0 * backward_once + backward_twice)
       entry_derivative = numerator / (12.0 * delta)
       derivatives_list.append(entry_derivative)  # shape is: [num_elts] + tf.shape(f())
     derivatives = tf.stack(derivatives_list)
+    # swap function and variable dims
+    derivatives = tf.transpose()
     # reshape to correct Jacobian shape.
-    all_derivatives.append(tf.reshape(derivatives, tf.shape(forward_twice) + tf.shape(var)))
+    all_derivatives.append(tf.reshape(derivatives, tf.concat([tf.shape(forward_twice), tf.shape(var)], 0)))
   return all_derivatives
     
     

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -330,5 +330,3 @@ def approximate_jacobian(f, variables, delta=5e-2):
     print(reshape_shape)
     all_derivatives.append(tf.reshape(derivatives, reshape_shape))
   return all_derivatives
-    
-    

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -314,12 +314,13 @@ def _five_point_stencil(f, var, i, delta):
   stencil = tf.nest.map_structure(lambda x: x / (12.0 * delta), numerator)
   return stencil
 
-def approximate_gradient(f, variables, delta=5e-2):
+
+def approximate_gradient(f, variables, delta=1e-1):
   """Approximates the gradient of f using five point stencil.
 
   Suppose the input function returns a possibly nested structure `r` under
   gradient tape `t`.  Then this function returns an approximation to
-  `t.gradient(r, variables)`.
+  `t.gradient(r, variables, unconnected_gradients=tf.UnconnectedGradients.ZERO)`
 
   Args:
     f: Callable taking no arguments and returning a possibly nested structure
@@ -349,11 +350,12 @@ def approximate_gradient(f, variables, delta=5e-2):
   return tf.nest.map_structure(var_gradient, variables)
 
 
-def approximate_jacobian(f, variables, delta=5e-2):
+def approximate_jacobian(f, variables, delta=1e-1):
   """Approximates the jacobian of f using five point stencil.
 
   Suppose the input function returns a tensor `r` under gradient tape `t`.  Then
-  this function returns an approximation to `t.jacobian(r, variables)`.
+  this function returns an approximation to
+  `t.jacobian(r, variables, unconnected_gradients=tf.UnconnectedGradients.ZERO)`
 
   Args:
     f: Callable taking no arguments and returning a `tf.Tensor`.

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -290,10 +290,8 @@ def approximate_gradient(f, variables, delta=1e-1):
     delta: Size of the fundamental perturbation in the stencil.
 
   Returns:
-    all_derivatives: List containing derivatives.  `all_derivatives[i]`
-      contains the gradient of `f()`with respect to `variables[i]`, which is the
-      sum over any non-variable dimensions of the jacobian of `f()` with respect
-      to `variables[i]`, hence has shape `tf.shape(variables[i])`.
+    The approximate gradient.  Has the same structure as the return from a
+      corresponding call to `tf.GradientTape().gradient`.
   """
 
   def var_gradient(var):
@@ -329,9 +327,8 @@ def approximate_jacobian(f, variables, delta=1e-1):
     delta: Size of the fundamental perturbation in the stencil.
 
   Returns:
-    all_derivatives: list containing derivatives.  `all_derivatives[i]`
-      contains the jacobian of `f()` with respect to `variables[i]`, and hence
-      has shape `tf.shape(f()) + tf.shape(variables[i])`.
+    The approximate jacobian.  Has the same structure as the return from a
+      corresponding call to `tf.GradientTape().jacobian`.
   """
 
   def var_jacobian(var):

--- a/tests/test_util_test.py
+++ b/tests/test_util_test.py
@@ -241,6 +241,7 @@ class ApproximateDerivativesTest(tf.test.TestCase):
     self.matrix_initial_value = tf.random.uniform(
         self.matrix_shape, minval, maxval)
     self.matrix_var = tf.Variable(self.matrix_initial_value)
+    self.variables_structure = [[self.scalar_var, self.vector_var], [self.matrix_var]]
 
     def linear_scalar():
       """Returns a scalar."""
@@ -257,37 +258,36 @@ class ApproximateDerivativesTest(tf.test.TestCase):
       return self.matrix_var.read_value()
     self.linear_matrix = linear_matrix
 
+    def f_tensor():
+      """Returns a combination of all three variables."""
+      return tf.linalg.matvec(self.matrix_var, self.vector_var) * self.scalar_var
+    self.f_tensor = f_tensor
+
   def test_linear_gradient(self):
     """Confirms correct Gradient values for linear functions."""
 
-    # test a nested structure of variables
-    variables_list = [[self.scalar_var, self.vector_var], [self.matrix_var]]
-    
     # scalar
     expected_gradient = [[tf.ones_like(self.scalar_var), tf.zeros_like(self.vector_var)], [tf.zeros_like(self.matrix_var)]]
-    actual_gradient = test_util.approximate_gradient(self.linear_scalar, variables_list)
+    actual_gradient = test_util.approximate_gradient(self.linear_scalar, self.variables_structure)
     tf.nest.map_structure(lambda a, e: self.assertAllClose(a, e, atol=self.close_atol), actual_gradient, expected_gradient)
 
     # vector
     expected_gradient = [[tf.zeros_like(self.scalar_var), tf.ones_like(self.vector_var)], [tf.zeros_like(self.matrix_var)]]
-    actual_gradient = test_util.approximate_gradient(self.linear_vector, variables_list)
+    actual_gradient = test_util.approximate_gradient(self.linear_vector, self.variables_structure)
     tf.nest.map_structure(lambda a, e: self.assertAllClose(a, e, atol=self.close_atol), actual_gradient, expected_gradient)
 
     # matrix
     expected_gradient = [[tf.zeros_like(self.scalar_var), tf.zeros_like(self.vector_var)], [tf.ones_like(self.matrix_var)]]
-    actual_gradient = test_util.approximate_gradient(self.linear_matrix, variables_list)
+    actual_gradient = test_util.approximate_gradient(self.linear_matrix, self.variables_structure)
     tf.nest.map_structure(lambda a, e: self.assertAllClose(a, e, atol=self.close_atol), actual_gradient, expected_gradient)
 
   def test_linear_jacobian(self):
     """Confirms correct Jacobian values for linear functions."""
 
-    # test a nested structure of variables
-    variables_list = [self.scalar_var, [self.vector_var, self.matrix_var]]
-
     # scalar
     scalar_jacobian = tf.constant(1.0)
-    expected_jacobian = [scalar_jacobian, [tf.zeros(self.vector_shape), tf.zeros(self.matrix_shape)]]
-    actual_jacobian = test_util.approximate_jacobian(self.linear_scalar, variables_list)
+    expected_jacobian = [[scalar_jacobian, tf.zeros(self.vector_shape)], [tf.zeros(self.matrix_shape)]]
+    actual_jacobian = test_util.approximate_jacobian(self.linear_scalar, self.variables_structure)
     tf.nest.map_structure(lambda a, e: self.assertAllClose(a, e, atol=self.close_atol), actual_jacobian, expected_jacobian)
 
     # vector
@@ -297,8 +297,8 @@ class ApproximateDerivativesTest(tf.test.TestCase):
         if i == j:
           vector_jacobian[i, j] = 1.0
     vector_jacobian = tf.constant(vector_jacobian)
-    expected_jacobian = [tf.zeros(self.vector_shape), [vector_jacobian, tf.zeros(self.vector_shape + self.matrix_shape)]]
-    actual_jacobian = test_util.approximate_jacobian(self.linear_vector, variables_list)
+    expected_jacobian = [[tf.zeros(self.vector_shape), vector_jacobian], [tf.zeros(self.vector_shape + self.matrix_shape)]]
+    actual_jacobian = test_util.approximate_jacobian(self.linear_vector, self.variables_structure)
     tf.nest.map_structure(lambda a, e: self.assertAllClose(a, e, atol=self.close_atol), actual_jacobian, expected_jacobian)
 
     # matrix
@@ -310,52 +310,49 @@ class ApproximateDerivativesTest(tf.test.TestCase):
             if i == k and j == l:
               matrix_jacobian[i, j, k, l] = 1.0
     matrix_jacobian = tf.constant(matrix_jacobian)
-    expected_jacobian = [tf.zeros(self.matrix_shape), [tf.zeros(self.matrix_shape + self.vector_shape), matrix_jacobian]]
-    actual_jacobian = test_util.approximate_jacobian(self.linear_matrix, variables_list)
+    expected_jacobian = [[tf.zeros(self.matrix_shape), tf.zeros(self.matrix_shape + self.vector_shape)], [matrix_jacobian]]
+    actual_jacobian = test_util.approximate_jacobian(self.linear_matrix, self.variables_structure)
     tf.nest.map_structure(lambda a, e: self.assertAllClose(a, e, atol=self.close_atol), actual_jacobian, expected_jacobian)
 
-  # def test_gradient(self):
-  #   """Checks gradient of nested return function."""
+  def test_gradient(self):
+    """Compares approximation against exact gradient."""
 
-  # def test_jacobian(self):
-  #   """Compares approximation against exact jacobian."""
+    def f_nested():
+      """Returns a nested structure."""
+      return [self.f_tensor(), [[self.f_tensor()], self.f_tensor()]]
 
-  #   # First, test with a linear function of the matrix variable.
-  #   def f_linear():
-  #     """Just the variable itself."""
-  #     return matrix_var.read_value()
-  #   actual_derivative = test_util.approximate_jacobian(f_linear, [matrix_var, vector_var])
-  #   expected_derivative_shapes = [[dimension_1, dimension_0, dimension_1, dimension_0], [dimension_1, dimension_0, dimension_0]]
-  #   self.assertEqual(len(actual_derivative), len(expected_derivative_shapes))
-  #   for a, e_shape in zip(actual_derivative, expected_derivative_shapes):
-  #     self.assertAllEqual(tf.shape(a), e_shape)
-  #   # The derivative of `f_linear()` should be 1 at [i, j, i, j].
-  #   expected_matrix_derivative = tf.one_(matrix_var)
-  #   expected_vector_derivative = tf.zeros_like(vector_var)
-  #   self.assertAllClose(actual_derivative[0], expected_matrix_derivative, rtol=self.close_rtol)
-  #   self.assertAllClose(actual_derivative[1], expected_vector_derivative, atol=self.zero_atol)
-    
-  #   def f_scalar():
-  #     """Scalar result of combining the variables."""
-  #     return tf.reduce_sum(tf.linalg.matvec(matrix_var, vector_var) * scalar_var)
+    for f in [self.f_tensor, f_nested]:
+      # test with respect to single variable
+      with tf.GradientTape() as tape:
+        value = f()
+      expected_gradient = tape.gradient(value, self.vector_var)
+      actual_gradient = test_util.approximate_gradient(f, self.vector_var)
+      self.assertNotAllClose(expected_gradient, tf.zeros_like(expected_gradient), atol=self.not_zero_atol)
+      self.assertAllClose(actual_gradient, expected_gradient, atol=self.close_atol)
 
-  #   def f_vector():
-  #     """Vector result of combining the variables."""
-  #     return tf.linalg.matvec(matrix_var, vector_var) * scalar_var
+      # test with respect to nested variable structure
+      with tf.GradientTape() as tape:
+        value = f()
+      expected_gradient = tape.gradient(value, self.variables_structure)
+      actual_gradient = test_util.approximate_gradient(f, self.variables_structure)
+      tf.nest.map_structure(lambda a: self.assertNotAllClose(a, tf.zeros_like(a), atol=self.not_zero_atol), actual_gradient)
+      tf.nest.map_structure(lambda a, e: self.assertAllClose(a, e, atol=self.close_atol), actual_gradient, expected_gradient)
 
-  #   def f_matrix():
-  #     """Matrix result of combining the variables."""
-  #     new_vec = vector_var * scalar_var
-  #     tiled_vec = tf.tile(tf.expand_dims(new_vec, 1), [1, dimension_1])
-  #     return tf.linalg.matmul(matrix_var, tiled_vec)
+  def test_jacobian(self):
+    """Compares approximation against exact jacobian."""
 
-  #   for f in [f_scalar, f_vector, f_matrix]:
-  #     with tf.GradientTape() as tape:
-  #       value = f()
-  #     expected_derivative = tape.jacobian(value, variable_list)
-  #     actual_derivative = test_util.approximate_jacobian(f, variable_list)
-  #     self.assertEqual(len(actual_derivative), len(variable_list))
-  #     for a, e in zip(actual_derivative, expected_derivative):
-  #       print(f"tf.shape(a): {tf.shape(a)}")
-  #       print(f"tf.shape(e): {tf.shape(e)}")
-  #       self.assertAllClose(a, e, rtol=self.close_rtol)
+    # test with respect to single variable
+    with tf.GradientTape() as tape:
+      value = self.f_tensor()
+    expected_jacobian = tape.jacobian(value, self.vector_var)
+    actual_jacobian = test_util.approximate_jacobian(self.f_tensor, self.vector_var)
+    self.assertNotAllClose(expected_jacobian, tf.zeros_like(expected_jacobian), atol=self.not_zero_atol)
+    self.assertAllClose(actual_jacobian, expected_jacobian, atol=self.close_atol)
+
+    # test with respect to nested variable structure
+    with tf.GradientTape() as tape:
+      value = self.f_tensor()
+    expected_jacobian = tape.jacobian(value, self.variables_structure)
+    actual_jacobian = test_util.approximate_jacobian(self.f_tensor, self.variables_structure)
+    tf.nest.map_structure(lambda a: self.assertNotAllClose(a, tf.zeros_like(a), atol=self.not_zero_atol), expected_jacobian)
+    tf.nest.map_structure(lambda a, e: self.assertAllClose(a, e, atol=self.close_atol), actual_jacobian, expected_jacobian)

--- a/tests/test_util_test.py
+++ b/tests/test_util_test.py
@@ -258,6 +258,27 @@ class ApproximateDerivativesTest(tf.test.TestCase):
       return self.matrix_var.read_value()
     self.linear_matrix = linear_matrix
 
+  def test_linear_gradient(self):
+    """Confirms correct Gradient values for linear functions."""
+
+    # scalar
+    expected_gradient = [tf.ones_like(self.scalar_var), tf.zeros_like(self.vector_var), tf.zeros_like(self.matrix_var)]
+    actual_gradient = test_util.approximate_gradient(self.linear_scalar, self.variables_list)
+    for a, e in zip(actual_gradient, expected_gradient):
+      self.assertAllClose(a, e, atol=self.close_atol)
+
+    # vector
+    expected_gradient = [tf.zeros_like(self.scalar_var), tf.ones_like(self.vector_var), tf.zeros_like(self.matrix_var)]
+    actual_gradient = test_util.approximate_gradient(self.linear_vector, self.variables_list)
+    for a, e in zip(actual_gradient, expected_gradient):
+      self.assertAllClose(a, e, atol=self.close_atol)
+
+    # matrix
+    expected_gradient = [tf.zeros_like(self.scalar_var), tf.zeros_like(self.vector_var), tf.ones_like(self.matrix_var)]
+    actual_gradient = test_util.approximate_gradient(self.linear_matrix, self.variables_list)
+    for a, e in zip(actual_gradient, expected_gradient):
+      self.assertAllClose(a, e, atol=self.close_atol)
+
   def test_linear_jacobian(self):
     """Confirms correct Jacobian values for linear functions."""
 

--- a/tests/test_util_test.py
+++ b/tests/test_util_test.py
@@ -314,7 +314,9 @@ class ApproximateDerivativesTest(tf.test.TestCase):
     actual_jacobian = test_util.approximate_jacobian(self.linear_matrix, self.variables_list)
     for a, e in zip(actual_jacobian, expected_jacobian):
       self.assertAllClose(a, e, atol=self.close_atol)
-    
+
+  # def test_gradient(self):
+  #   """Checks gradient of nested return function."""
 
   # def test_jacobian(self):
   #   """Compares approximation against exact jacobian."""

--- a/tests/test_util_test.py
+++ b/tests/test_util_test.py
@@ -217,3 +217,7 @@ class PerturbFunctionTest(tf.test.TestCase, parameterized.TestCase):
                             actual_return)
       tf.nest.map_structure(self.assertAllClose, actual_return, expected_return)
       self.assertAllClose(matrix_var, matrix_initial_value)
+
+
+class ApproximateJacobianTest(tf.test.TestCase):
+  """Tests the approximate_jacobian function."""

--- a/tests/test_util_test.py
+++ b/tests/test_util_test.py
@@ -222,27 +222,62 @@ class PerturbFunctionTest(tf.test.TestCase, parameterized.TestCase):
 class ApproximateJacobianTest(tf.test.TestCase):
   """Tests the approximate_jacobian function."""
 
+  def setUp(self):
+    super().setUp()
+    self.close_rtol = 1e-4
+    self.zero_atol = 1e-4
+
   def test_jacobian(self):
     """Compares approximation against exact jacobian."""
-    dimension = 7
+    dimension_0 = 7
+    dimension_1 = 4
     minval = -5
     maxval = 5
     scalar_initial_value = tf.random.uniform([], minval, maxval)
     scalar_var = tf.Variable(scalar_initial_value)
-    vector_initial_value = tf.random.uniform([dimension], minval, maxval)
+    vector_initial_value = tf.random.uniform([dimension_0], minval, maxval)
     vector_var = tf.Variable(vector_initial_value)
     matrix_initial_value = tf.random.uniform(
-        [dimension, dimension], minval, maxval)
+        [dimension_1, dimension_0], minval, maxval)
     matrix_var = tf.Variable(matrix_initial_value)
     variable_list = [scalar_var, vector_var, matrix_var]
 
-    def f():
+    # First, test with a linear function of the matrix variable.
+    def f_linear():
+      """Just the variable itself."""
+      return matrix_var.read_value()
+    actual_derivative = test_util.approximate_jacobian(f_linear, [matrix_var, vector_var])
+    expected_derivative_shapes = [[dimension_1, dimension_0, dimension_1, dimension_0], [dimension_1, dimension_0, dimension_0]]
+    self.assertEqual(len(actual_derivative), len(expected_derivative_shapes))
+    for a, e_shape in zip(actual_derivative, expected_derivative_shapes):
+      self.assertAllEqual(tf.shape(a), e_shape)
+    # The derivative of `f_linear()` should be 1 at [i, j, i, j].
+    expected_matrix_derivative = tf.one_(matrix_var)
+    expected_vector_derivative = tf.zeros_like(vector_var)
+    self.assertAllClose(actual_derivative[0], expected_matrix_derivative, rtol=self.close_rtol)
+    self.assertAllClose(actual_derivative[1], expected_vector_derivative, atol=self.zero_atol)
+    
+    def f_scalar():
+      """Scalar result of combining the variables."""
+      return tf.reduce_sum(tf.linalg.matvec(matrix_var, vector_var) * scalar_var)
+
+    def f_vector():
       """Vector result of combining the variables."""
       return tf.linalg.matvec(matrix_var, vector_var) * scalar_var
 
-    with tf.GradientTape() as tape:
-      value = f()
-    expected_derivative = tape.jacobian(value, variable_list)
+    def f_matrix():
+      """Matrix result of combining the variables."""
+      new_vec = vector_var * scalar_var
+      tiled_vec = tf.tile(tf.expand_dims(new_vec, 1), [1, dimension_1])
+      return tf.linalg.matmul(matrix_var, tiled_vec)
 
-    actual_derivative = test_util.approximate_jacobian(f, variable_list)
-    self.assertAllClose(actual_derivative, expected_derivative)
+    for f in [f_scalar, f_vector, f_matrix]:
+      with tf.GradientTape() as tape:
+        value = f()
+      expected_derivative = tape.jacobian(value, variable_list)
+      actual_derivative = test_util.approximate_jacobian(f, variable_list)
+      self.assertEqual(len(actual_derivative), len(variable_list))
+      for a, e in zip(actual_derivative, expected_derivative):
+        print(f"tf.shape(a): {tf.shape(a)}")
+        print(f"tf.shape(e): {tf.shape(e)}")
+        self.assertAllClose(a, e, rtol=self.close_rtol)

--- a/tests/test_util_test.py
+++ b/tests/test_util_test.py
@@ -15,7 +15,6 @@
 """Tests for tests.test_util"""
 
 from absl.testing import parameterized
-import random
 
 import cirq
 import sympy
@@ -235,7 +234,7 @@ class ApproximateJacobianTest(tf.test.TestCase):
     matrix_initial_value = tf.random.uniform(
         [dimension, dimension], minval, maxval)
     matrix_var = tf.Variable(matrix_initial_value)
-    variable_list = random.shuffle([scalar_var, vector_var, matrix_var])
+    variable_list = [scalar_var, vector_var, matrix_var]
 
     def f():
       """Vector result of combining the variables."""

--- a/tests/test_util_test.py
+++ b/tests/test_util_test.py
@@ -232,35 +232,43 @@ class ApproximateDerivativesTest(tf.test.TestCase):
     minval = -5
     maxval = 5
     self.scalar_shape = []
-    self.scalar_initial_value = tf.random.uniform(self.scalar_shape, minval, maxval)
+    self.scalar_initial_value = tf.random.uniform(self.scalar_shape, minval,
+                                                  maxval)
     self.scalar_var = tf.Variable(self.scalar_initial_value)
     self.vector_shape = [dimension_0]
-    self.vector_initial_value = tf.random.uniform(self.vector_shape, minval, maxval)
+    self.vector_initial_value = tf.random.uniform(self.vector_shape, minval,
+                                                  maxval)
     self.vector_var = tf.Variable(self.vector_initial_value)
     self.matrix_shape = [dimension_1, dimension_0]
-    self.matrix_initial_value = tf.random.uniform(
-        self.matrix_shape, minval, maxval)
+    self.matrix_initial_value = tf.random.uniform(self.matrix_shape, minval,
+                                                  maxval)
     self.matrix_var = tf.Variable(self.matrix_initial_value)
-    self.variables_structure = [[self.scalar_var, self.vector_var], [self.matrix_var]]
+    self.variables_structure = [[self.scalar_var, self.vector_var],
+                                [self.matrix_var]]
 
     def linear_scalar():
       """Returns a scalar."""
       return tf.identity(self.scalar_var)
+
     self.linear_scalar = linear_scalar
 
     def linear_vector():
       """Returns a vector."""
       return tf.identity(self.vector_var)
+
     self.linear_vector = linear_vector
 
     def linear_matrix():
       """Returns a matrix."""
       return tf.identity(self.matrix_var)
+
     self.linear_matrix = linear_matrix
 
     def f_tensor():
       """Returns a combination of all three variables."""
-      return tf.linalg.matvec(self.matrix_var, self.vector_var) * self.scalar_var
+      return tf.linalg.matvec(self.matrix_var,
+                              self.vector_var) * self.scalar_var
+
     self.f_tensor = f_tensor
 
   @test_util.eager_mode_toggle
@@ -270,19 +278,37 @@ class ApproximateDerivativesTest(tf.test.TestCase):
     approximate_gradient_wrapper = tf.function(test_util.approximate_gradient)
 
     # scalar
-    expected_gradient = [[tf.ones_like(self.scalar_var), tf.zeros_like(self.vector_var)], [tf.zeros_like(self.matrix_var)]]
-    actual_gradient = approximate_gradient_wrapper(self.linear_scalar, self.variables_structure)
-    tf.nest.map_structure(lambda a, e: self.assertAllClose(a, e, atol=self.close_atol), actual_gradient, expected_gradient)
+    expected_gradient = [[
+        tf.ones_like(self.scalar_var),
+        tf.zeros_like(self.vector_var)
+    ], [tf.zeros_like(self.matrix_var)]]
+    actual_gradient = approximate_gradient_wrapper(self.linear_scalar,
+                                                   self.variables_structure)
+    tf.nest.map_structure(
+        lambda a, e: self.assertAllClose(a, e, atol=self.close_atol),
+        actual_gradient, expected_gradient)
 
     # vector
-    expected_gradient = [[tf.zeros_like(self.scalar_var), tf.ones_like(self.vector_var)], [tf.zeros_like(self.matrix_var)]]
-    actual_gradient = approximate_gradient_wrapper(self.linear_vector, self.variables_structure)
-    tf.nest.map_structure(lambda a, e: self.assertAllClose(a, e, atol=self.close_atol), actual_gradient, expected_gradient)
+    expected_gradient = [[
+        tf.zeros_like(self.scalar_var),
+        tf.ones_like(self.vector_var)
+    ], [tf.zeros_like(self.matrix_var)]]
+    actual_gradient = approximate_gradient_wrapper(self.linear_vector,
+                                                   self.variables_structure)
+    tf.nest.map_structure(
+        lambda a, e: self.assertAllClose(a, e, atol=self.close_atol),
+        actual_gradient, expected_gradient)
 
     # matrix
-    expected_gradient = [[tf.zeros_like(self.scalar_var), tf.zeros_like(self.vector_var)], [tf.ones_like(self.matrix_var)]]
-    actual_gradient = approximate_gradient_wrapper(self.linear_matrix, self.variables_structure)
-    tf.nest.map_structure(lambda a, e: self.assertAllClose(a, e, atol=self.close_atol), actual_gradient, expected_gradient)
+    expected_gradient = [[
+        tf.zeros_like(self.scalar_var),
+        tf.zeros_like(self.vector_var)
+    ], [tf.ones_like(self.matrix_var)]]
+    actual_gradient = approximate_gradient_wrapper(self.linear_matrix,
+                                                   self.variables_structure)
+    tf.nest.map_structure(
+        lambda a, e: self.assertAllClose(a, e, atol=self.close_atol),
+        actual_gradient, expected_gradient)
 
   @test_util.eager_mode_toggle
   def test_linear_jacobian(self):
@@ -290,9 +316,14 @@ class ApproximateDerivativesTest(tf.test.TestCase):
 
     # scalar
     scalar_jacobian = tf.constant(1.0)
-    expected_jacobian = [[scalar_jacobian, tf.zeros(self.vector_shape)], [tf.zeros(self.matrix_shape)]]
-    actual_jacobian = test_util.approximate_jacobian(self.linear_scalar, self.variables_structure)
-    tf.nest.map_structure(lambda a, e: self.assertAllClose(a, e, atol=self.close_atol), actual_jacobian, expected_jacobian)
+    expected_jacobian = [[scalar_jacobian,
+                          tf.zeros(self.vector_shape)],
+                         [tf.zeros(self.matrix_shape)]]
+    actual_jacobian = test_util.approximate_jacobian(self.linear_scalar,
+                                                     self.variables_structure)
+    tf.nest.map_structure(
+        lambda a, e: self.assertAllClose(a, e, atol=self.close_atol),
+        actual_jacobian, expected_jacobian)
 
     # vector
     vector_jacobian = np.zeros(self.vector_shape + self.vector_shape)
@@ -301,9 +332,13 @@ class ApproximateDerivativesTest(tf.test.TestCase):
         if i == j:
           vector_jacobian[i, j] = 1.0
     vector_jacobian = tf.constant(vector_jacobian)
-    expected_jacobian = [[tf.zeros(self.vector_shape), vector_jacobian], [tf.zeros(self.vector_shape + self.matrix_shape)]]
-    actual_jacobian = test_util.approximate_jacobian(self.linear_vector, self.variables_structure)
-    tf.nest.map_structure(lambda a, e: self.assertAllClose(a, e, atol=self.close_atol), actual_jacobian, expected_jacobian)
+    expected_jacobian = [[tf.zeros(self.vector_shape), vector_jacobian],
+                         [tf.zeros(self.vector_shape + self.matrix_shape)]]
+    actual_jacobian = test_util.approximate_jacobian(self.linear_vector,
+                                                     self.variables_structure)
+    tf.nest.map_structure(
+        lambda a, e: self.assertAllClose(a, e, atol=self.close_atol),
+        actual_jacobian, expected_jacobian)
 
     # matrix
     matrix_jacobian = np.zeros(self.matrix_shape + self.matrix_shape)
@@ -314,9 +349,15 @@ class ApproximateDerivativesTest(tf.test.TestCase):
             if i == k and j == l:
               matrix_jacobian[i, j, k, l] = 1.0
     matrix_jacobian = tf.constant(matrix_jacobian)
-    expected_jacobian = [[tf.zeros(self.matrix_shape), tf.zeros(self.matrix_shape + self.vector_shape)], [matrix_jacobian]]
-    actual_jacobian = test_util.approximate_jacobian(self.linear_matrix, self.variables_structure)
-    tf.nest.map_structure(lambda a, e: self.assertAllClose(a, e, atol=self.close_atol), actual_jacobian, expected_jacobian)
+    expected_jacobian = [[
+        tf.zeros(self.matrix_shape),
+        tf.zeros(self.matrix_shape + self.vector_shape)
+    ], [matrix_jacobian]]
+    actual_jacobian = test_util.approximate_jacobian(self.linear_matrix,
+                                                     self.variables_structure)
+    tf.nest.map_structure(
+        lambda a, e: self.assertAllClose(a, e, atol=self.close_atol),
+        actual_jacobian, expected_jacobian)
 
   @test_util.eager_mode_toggle
   def test_gradient(self):
@@ -332,16 +373,25 @@ class ApproximateDerivativesTest(tf.test.TestCase):
         value = f()
       expected_gradient = tape.gradient(value, self.vector_var)
       actual_gradient = test_util.approximate_gradient(f, self.vector_var)
-      self.assertNotAllClose(expected_gradient, tf.zeros_like(expected_gradient), atol=self.not_zero_atol)
-      self.assertAllClose(actual_gradient, expected_gradient, atol=self.close_atol)
+      self.assertNotAllClose(
+          expected_gradient,
+          tf.zeros_like(expected_gradient),
+          atol=self.not_zero_atol)
+      self.assertAllClose(
+          actual_gradient, expected_gradient, atol=self.close_atol)
 
       # test with respect to nested variable structure
       with tf.GradientTape() as tape:
         value = f()
       expected_gradient = tape.gradient(value, self.variables_structure)
-      actual_gradient = test_util.approximate_gradient(f, self.variables_structure)
-      tf.nest.map_structure(lambda a: self.assertNotAllClose(a, tf.zeros_like(a), atol=self.not_zero_atol), actual_gradient)
-      tf.nest.map_structure(lambda a, e: self.assertAllClose(a, e, atol=self.close_atol), actual_gradient, expected_gradient)
+      actual_gradient = test_util.approximate_gradient(f,
+                                                       self.variables_structure)
+      tf.nest.map_structure(
+          lambda a: self.assertNotAllClose(
+              a, tf.zeros_like(a), atol=self.not_zero_atol), actual_gradient)
+      tf.nest.map_structure(
+          lambda a, e: self.assertAllClose(a, e, atol=self.close_atol),
+          actual_gradient, expected_gradient)
 
   @test_util.eager_mode_toggle
   def test_jacobian(self):
@@ -351,14 +401,24 @@ class ApproximateDerivativesTest(tf.test.TestCase):
     with tf.GradientTape() as tape:
       value = self.f_tensor()
     expected_jacobian = tape.jacobian(value, self.vector_var)
-    actual_jacobian = test_util.approximate_jacobian(self.f_tensor, self.vector_var)
-    self.assertNotAllClose(expected_jacobian, tf.zeros_like(expected_jacobian), atol=self.not_zero_atol)
-    self.assertAllClose(actual_jacobian, expected_jacobian, atol=self.close_atol)
+    actual_jacobian = test_util.approximate_jacobian(self.f_tensor,
+                                                     self.vector_var)
+    self.assertNotAllClose(
+        expected_jacobian,
+        tf.zeros_like(expected_jacobian),
+        atol=self.not_zero_atol)
+    self.assertAllClose(
+        actual_jacobian, expected_jacobian, atol=self.close_atol)
 
     # test with respect to nested variable structure
     with tf.GradientTape() as tape:
       value = self.f_tensor()
     expected_jacobian = tape.jacobian(value, self.variables_structure)
-    actual_jacobian = test_util.approximate_jacobian(self.f_tensor, self.variables_structure)
-    tf.nest.map_structure(lambda a: self.assertNotAllClose(a, tf.zeros_like(a), atol=self.not_zero_atol), expected_jacobian)
-    tf.nest.map_structure(lambda a, e: self.assertAllClose(a, e, atol=self.close_atol), actual_jacobian, expected_jacobian)
+    actual_jacobian = test_util.approximate_jacobian(self.f_tensor,
+                                                     self.variables_structure)
+    tf.nest.map_structure(
+        lambda a: self.assertNotAllClose(
+            a, tf.zeros_like(a), atol=self.not_zero_atol), expected_jacobian)
+    tf.nest.map_structure(
+        lambda a, e: self.assertAllClose(a, e, atol=self.close_atol),
+        actual_jacobian, expected_jacobian)


### PR DESCRIPTION
Add approximations to `tape.gradient` and `tape.jacobian`.  Resolves #206.

To test derivatives of various library functions, I have been comparing the autodiff values to a five point stencil on the forward pass.  Test utilities `approximate_derivative` and `approximate_derivative_unsummed` were developed for this purpose.  However, these functions still required extra boilerplate and did not have the same interface as TensorFlow's built in tape derivative functions.

To simplify derivative testing, here two new utility functions are implemented: `approximate_gradient` and `approximate_jacobian`.  These are written such that, for function `f` and possibly nested structure `vars` of `tf.Variable`s participating in the calculation of `f()`, if we write
```python
with tf.GradientTape as tape:
  value = f()
auto_grad = tape.gradient(value, vars)
approx_grad = test_util.approximate_gradient(f, vars)
```
then `approx_grad` is a five point stencil approximation to `auto_grad`.