### PR TITLE
Update DirectQuantumCircuit initializer range

### DIFF
--- a/qhbmlib/models/circuit.py
+++ b/qhbmlib/models/circuit.py
@@ -195,7 +195,7 @@ class DirectQuantumCircuit(QuantumCircuit):
       initializer: A `tf.keras.initializers.Initializer` which specifies how to
         initialize the values of the parameters in `circuit`.  The default
         initializer assumes parameters of gates are exponents, so that one full
-        period is covered by the parameter range 0 to 2. 
+        period is covered by the parameter range 0 to 2.
       name: Optional name for the model.
     """
     raw_symbol_names = list(sorted(tfq.util.get_circuit_symbols(pqc)))

--- a/qhbmlib/models/circuit.py
+++ b/qhbmlib/models/circuit.py
@@ -185,7 +185,7 @@ class DirectQuantumCircuit(QuantumCircuit):
       self,
       pqc: cirq.Circuit,
       initializer: tf.keras.initializers.Initializer = tf.keras.initializers
-      .RandomUniform(0, 2 * np.pi),
+      .RandomUniform(0, 2),
       name: Union[None, str] = None,
   ):
     """Initializes a DirectQuantumCircuit.
@@ -193,7 +193,9 @@ class DirectQuantumCircuit(QuantumCircuit):
     Args:
       pqc: Representation of a parameterized quantum circuit.
       initializer: A `tf.keras.initializers.Initializer` which specifies how to
-        initialize the values of the parameters in `circuit`.
+        initialize the values of the parameters in `circuit`.  The default
+        initializer assumes parameters of gates are exponents, so that one full
+        period is covered by the parameter range 0 to 2. 
       name: Optional name for the model.
     """
     raw_symbol_names = list(sorted(tfq.util.get_circuit_symbols(pqc)))

--- a/tests/model/circuit_test.py
+++ b/tests/model/circuit_test.py
@@ -17,12 +17,14 @@
 import absl
 import itertools
 import random
+import string
 
 import cirq
 import sympy
 import tensorflow as tf
 from tensorflow.python.framework import errors
 import tensorflow_quantum as tfq
+from tensorflow_quantum.python import util as tfq_util
 
 from qhbmlib import models
 from qhbmlib import utils
@@ -264,6 +266,19 @@ class DirectQuantumCircuitTest(tf.test.TestCase):
     self.assertAllEqual(
         tfq.from_tensor(actual_qnn.pqc),
         tfq.from_tensor(tfq.convert_to_tensor([expected_pqc])))
+
+  def test_default_init(self):
+    """Confirms default initializer sets values in expected range."""
+    num_qubits = 10
+    qubits = cirq.GridQubit.rect(num_qubits, 1)
+    symbols = set()
+    num_symbols = 100
+    for _ in range(num_symbols):
+      symbols.add("".join(random.sample(string.ascii_letters, 10)))
+    pqc = tfq_util.random_symbol_circuit(qubits, symbols)
+    actual_circuit = models.DirectQuantumCircuit(pqc)
+    actual_circuit.build([])
+    self.assertAllInRange(actual_circuit.symbol_values, 0, 2)
 
 
 class QAIATest(tf.test.TestCase):


### PR DESCRIPTION
Resolves #149 

Change bounds on default `DirectQuantumCircuit` initializer to cover one period of gates defined via exponents of idempotent matrices.  Updates the docstring to explain the motivation for the bounds on the default initializer.