### PR TITLE
Replace scipy random matrix test utilities with TensorFlow versions

### DIFF
--- a/tests/inference/qhbm_utils_test.py
+++ b/tests/inference/qhbm_utils_test.py
@@ -90,8 +90,8 @@ class FidelityTest(tf.test.TestCase):
     num_rerolls = 5
     for _ in range(num_rerolls):
       num_qubits = 4
-      sigma, _ = test_util.random_mixed_density_matrix(
-          num_qubits, 2**num_qubits)
+      sigma, _ = test_util.random_mixed_density_matrix(num_qubits,
+                                                       2**num_qubits)
       sigma_complex64 = tf.cast(sigma, tf.complex64)
       sigma_complex128 = tf.cast(sigma, tf.complex128)
 

--- a/tests/inference/qhbm_utils_test.py
+++ b/tests/inference/qhbm_utils_test.py
@@ -90,7 +90,7 @@ class FidelityTest(tf.test.TestCase):
     num_rerolls = 5
     for _ in range(num_rerolls):
       num_qubits = 4
-      sigma, _ = test_util.generate_mixed_random_density_operator(
+      sigma, _ = test_util.random_mixed_density_operator(
           num_qubits, 2**num_qubits)
       sigma_complex64 = tf.cast(sigma, tf.complex64)
       sigma_complex128 = tf.cast(sigma, tf.complex128)

--- a/tests/inference/qhbm_utils_test.py
+++ b/tests/inference/qhbm_utils_test.py
@@ -90,7 +90,7 @@ class FidelityTest(tf.test.TestCase):
     num_rerolls = 5
     for _ in range(num_rerolls):
       num_qubits = 4
-      sigma, _ = test_util.random_mixed_density_operator(
+      sigma, _ = test_util.random_mixed_density_matrix(
           num_qubits, 2**num_qubits)
       sigma_complex64 = tf.cast(sigma, tf.complex64)
       sigma_complex128 = tf.cast(sigma, tf.complex128)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -193,37 +193,6 @@ def random_pure_density_matrix(num_qubits):
   return matrix
 
 
-def generate_mixed_random_density_operator_pair(num_qubits, perm_basis=False):
-  num_mixtures = 5
-  dim = 2**num_qubits
-  # Use common basis
-  unitary = scipy.stats.unitary_group.rvs(dim)
-
-  prob = tf.random.uniform(shape=[num_mixtures])
-  prob = prob / tf.reduce_sum(prob)
-  final_state1 = tf.zeros((dim, dim), dtype=tf.complex128)
-  basis_indices = np.random.permutation(dim)[:num_mixtures]
-  for i, idx in enumerate(basis_indices):
-    u_vec = unitary[:, idx:idx + 1]
-    final_state1 += tf.multiply(
-        tf.cast(prob[i], dtype=tf.complex128),
-        tf.matmul(u_vec, u_vec, adjoint_b=True),
-    )
-
-  prob = tf.random.uniform(shape=[num_mixtures])
-  prob = prob / tf.reduce_sum(prob)
-  final_state2 = tf.zeros((dim, dim), dtype=tf.complex128)
-  if perm_basis:
-    basis_indices = np.random.permutation(dim)[:num_mixtures]
-  for i, idx in enumerate(basis_indices):
-    u_vec = unitary[:, idx:idx + 1]
-    final_state2 += tf.multiply(
-        tf.cast(prob[i], dtype=tf.complex128),
-        tf.matmul(u_vec, u_vec, adjoint_b=True),
-    )
-  return final_state1, final_state2
-
-
 def stable_classical_entropy(probs):
   """Entropy function for a list of probabilities, allowing zeros."""
   return -tf.reduce_sum(tf.math.multiply_no_nan(tf.math.log(probs), probs))

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -190,16 +190,6 @@ def random_mixed_density_matrix(num_qubits, num_mixtures=5):
   return final_state, mixture_probabilities
 
 
-def random_pure_density_matrix(num_qubits):
-  """Returns a random pure density matrix.
-
-  Args:
-    num_qubits: Number of qubits on which the matrix acts.
-  """
-  matrix, _ = random_mixed_density_matrix(num_qubits, 1)
-  return matrix
-
-
 def stable_classical_entropy(probs):
   """Entropy function for a list of probabilities, allowing zeros."""
   return -tf.reduce_sum(tf.math.multiply_no_nan(tf.math.log(probs), probs))

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -138,8 +138,12 @@ def random_hermitian_matrix(num_qubits):
   """
   dim = 2**num_qubits
   val_range = 2
-  random_real = tf.cast(tf.random.uniform([dim, dim], minval=-val_range, maxval=val_range), tf.complex128)
-  random_imag = tf.cast(tf.random.uniform([dim, dim], minval=-val_range, maxval=val_range), tf.complex128)
+  random_real = tf.cast(
+      tf.random.uniform([dim, dim], minval=-val_range, maxval=val_range),
+      tf.complex128)
+  random_imag = tf.cast(
+      tf.random.uniform([dim, dim], minval=-val_range, maxval=val_range),
+      tf.complex128)
   random_matrix = random_real + random_imag
   return random_matrix + tf.linalg.adjoint(random_matrix)
 
@@ -173,13 +177,16 @@ def random_mixed_density_matrix(num_qubits, num_mixtures=5):
   pre_probs = tf.random.uniform(shape=[num_mixtures])
   mixture_probabilities = pre_probs / tf.reduce_sum(pre_probs)
   random_unitary = random_unitary_matrix(num_qubits)
-  dim = 2 ** num_qubits
+  dim = 2**num_qubits
   final_state = tf.zeros([dim, dim], tf.complex128)
   for i in range(num_mixtures):
     pure_state = tf.one_hot(i, dim, dtype=tf.complex128)
     evolved_pure_state = tf.linalg.matvec(random_unitary, pure_state)
-    adjoint_evolved_pure_state = tf.squeeze(tf.linalg.adjoint(tf.expand_dims(evolved_pure_state, 0)))
-    final_state = final_state + tf.cast(mixture_probabilities[i], tf.complex128) * tf.einsum("i,j->ij", evolved_pure_state, adjoint_evolved_pure_state)
+    adjoint_evolved_pure_state = tf.squeeze(
+        tf.linalg.adjoint(tf.expand_dims(evolved_pure_state, 0)))
+    final_state = final_state + tf.cast(
+        mixture_probabilities[i], tf.complex128) * tf.einsum(
+            "i,j->ij", evolved_pure_state, adjoint_evolved_pure_state)
   return final_state, mixture_probabilities
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -100,34 +100,6 @@ def get_random_hamiltonian_and_inference(qubits,
   return random_qhbm.modular_hamiltonian, random_qhbm
 
 
-def get_random_pauli_sum(qubits):
-  """Test fixture.
-    Args:
-      qubits: A list of `cirq.GridQubit`s on which to build the pauli sum.
-    Returns:
-      pauli_sum: A `cirq.PauliSum` which is a linear combination of random pauli
-      strings on `qubits`.
-    """
-  paulis = [cirq.X, cirq.Y, cirq.Z]
-
-  coeff_max = 1.5
-  coeff_min = -1.0 * coeff_max
-
-  num_qubits = len(qubits)
-  num_pauli_terms = max(1, num_qubits - 1)
-  num_pauli_factors = max(1, num_qubits - 1)
-
-  pauli_sum = cirq.PauliSum()
-  for _ in range(num_pauli_terms):
-    pauli_term = random.uniform(coeff_min, coeff_max) * cirq.I(qubits[0])
-    sub_qubits = random.sample(qubits, num_pauli_factors)
-    for q in sub_qubits:
-      pauli_factor = random.choice(paulis)(q)
-      pauli_term *= pauli_factor
-    pauli_sum += pauli_term
-  return pauli_sum
-
-
 def random_hermitian_matrix(num_qubits):
   """Returns a random Hermitian matrix.
 
@@ -188,11 +160,6 @@ def random_mixed_density_matrix(num_qubits, num_mixtures=5):
         mixture_probabilities[i], tf.complex128) * tf.einsum(
             "i,j->ij", evolved_pure_state, adjoint_evolved_pure_state)
   return final_state, mixture_probabilities
-
-
-def stable_classical_entropy(probs):
-  """Entropy function for a list of probabilities, allowing zeros."""
-  return -tf.reduce_sum(tf.math.multiply_no_nan(tf.math.log(probs), probs))
 
 
 def check_bitstring_exists(bitstring, bitstring_list):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -113,7 +113,7 @@ def random_hermitian_matrix(num_qubits):
   random_real = tf.cast(
       tf.random.uniform([dim, dim], minval=-val_range, maxval=val_range),
       tf.complex128)
-  random_imag = tf.cast(
+  random_imag = 1j * tf.cast(
       tf.random.uniform([dim, dim], minval=-val_range, maxval=val_range),
       tf.complex128)
   random_matrix = random_real + random_imag
@@ -146,7 +146,7 @@ def random_mixed_density_matrix(num_qubits, num_mixtures=5):
     final_state: The mixed density matrix.
     mixture_probabilities: The probability of each state in the mixture.
   """
-  pre_probs = tf.random.uniform(shape=[num_mixtures])
+  pre_probs = tf.random.uniform(shape=[num_mixtures], minval=1e-9)
   mixture_probabilities = pre_probs / tf.reduce_sum(pre_probs)
   random_unitary = random_unitary_matrix(num_qubits)
   dim = 2**num_qubits

--- a/tests/test_util_test.py
+++ b/tests/test_util_test.py
@@ -100,7 +100,7 @@ class RandomMatrixTest(tf.test.TestCase):
 
   def setUp(self):
     """Initialize test objects."""
-    self.setUp()
+    super().setUp()
     self.num_qubits_list = [1, 2, 3, 4, 5]
 
   def test_random_hermitian_matrix(self):

--- a/tests/test_util_test.py
+++ b/tests/test_util_test.py
@@ -110,7 +110,7 @@ class RandomMatrixTest(tf.test.TestCase):
     """
     for n in self.num_qubits_list:
       actual_matrix = test_util.random_hermitian_matrix(n)
-      expected_dim = 2 ** n
+      expected_dim = 2**n
       self.assertAllEqual(tf.shape(actual_matrix), [expected_dim, expected_dim])
       self.assertAllEqual(actual_matrix, tf.linalg.adjoint(actual_matrix))
 
@@ -122,7 +122,7 @@ class RandomMatrixTest(tf.test.TestCase):
     """
     for n in self.num_qubits_list:
       actual_matrix = test_util.random_unitary_matrix(n)
-      expected_dim = 2 ** n
+      expected_dim = 2**n
       self.assertAllEqual(tf.shape(actual_matrix), [expected_dim, expected_dim])
       udu = tf.linalg.matmul(tf.linalg.adjoint(actual_matrix), actual_matrix)
       uud = tf.linalg.matmul(actual_matrix, tf.linalg.adjoint(actual_matrix))
@@ -136,11 +136,13 @@ class RandomMatrixTest(tf.test.TestCase):
     https://en.wikipedia.org/wiki/Density_matrix
     """
     for n in self.num_qubits_list:
-      expected_dim = 2 ** n
+      expected_dim = 2**n
       mixture_list = list(range(1, expected_dim + 1))
       for m in mixture_list:
-        actual_matrix, actual_probs = test_util.random_mixed_density_matrix(n, m)        
-        self.assertAllEqual(tf.shape(actual_matrix), [expected_dim, expected_dim])
+        actual_matrix, actual_probs = test_util.random_mixed_density_matrix(
+            n, m)
+        self.assertAllEqual(
+            tf.shape(actual_matrix), [expected_dim, expected_dim])
         self.assertAllEqual(tf.shape(actual_probs), [m])
         self.assertAllEqual(actual_matrix, tf.linalg.adjoint(actual_matrix))
         # Eigenvalues are real since we confirmed self-adjointness
@@ -163,7 +165,7 @@ class RandomMatrixTest(tf.test.TestCase):
     """
     for n in self.num_qubits_list:
       actual_matrix = test_util.random_pure_density_matrix(n)
-      expected_dim = 2 ** n
+      expected_dim = 2**n
       self.assertAllEqual(tf.shape(actual_matrix), [expected_dim, expected_dim])
       self.assertAllEqual(actual_matrix, tf.linalg.adjoint(actual_matrix))
       # Eigenvalues are real since we confirmed self-adjointness
@@ -172,7 +174,8 @@ class RandomMatrixTest(tf.test.TestCase):
       self.assertAllGreaterEqual(eigvals, -eigval_tol)
       self.assertAllClose(tf.linalg.trace(actual_matrix), 1.0)
       # Confirm purity
-      self.assertAllClose(tf.linalg.trace(tf.linalg.matmul(actual_matrix, actual_matrix)), 1.0)
+      self.assertAllClose(
+          tf.linalg.trace(tf.linalg.matmul(actual_matrix, actual_matrix)), 1.0)
 
 
 class EagerModeToggleTest(tf.test.TestCase):

--- a/tests/test_util_test.py
+++ b/tests/test_util_test.py
@@ -100,6 +100,7 @@ class RandomMatrixTest(tf.test.TestCase):
 
   def setUp(self):
     """Initialize test objects."""
+    self.setUp()
     self.num_qubits_list = [1, 2, 3, 4, 5]
 
   def test_random_hermitian_matrix(self):

--- a/tests/test_util_test.py
+++ b/tests/test_util_test.py
@@ -156,27 +156,6 @@ class RandomMatrixTest(tf.test.TestCase):
         self.assertAllClose(tf.reduce_sum(expected_sorted_probs), 1.0)
         self.assertAllClose(actual_sorted_probs, expected_sorted_probs)
 
-  def test_random_pure_density_operator(self):
-    """Checks that the returned matrix is a pure density matrix.
-
-    Density matrices are positive operators with trace one.  Additionally, a
-    pure density operator is idempotent.  See Wikipedia,
-    https://en.wikipedia.org/wiki/Density_matrix
-    """
-    for n in self.num_qubits_list:
-      actual_matrix = test_util.random_pure_density_matrix(n)
-      expected_dim = 2**n
-      self.assertAllEqual(tf.shape(actual_matrix), [expected_dim, expected_dim])
-      self.assertAllEqual(actual_matrix, tf.linalg.adjoint(actual_matrix))
-      # Eigenvalues are real since we confirmed self-adjointness
-      eigvals = tf.cast(tf.linalg.eigvalsh(actual_matrix), tf.float32)
-      eigval_tol = 1e-7
-      self.assertAllGreaterEqual(eigvals, -eigval_tol)
-      self.assertAllClose(tf.linalg.trace(actual_matrix), 1.0)
-      # Confirm purity
-      self.assertAllClose(
-          tf.linalg.trace(tf.linalg.matmul(actual_matrix, actual_matrix)), 1.0)
-
 
 class EagerModeToggleTest(tf.test.TestCase):
   """Tests eager_mode_toggle."""

--- a/tests/test_util_test.py
+++ b/tests/test_util_test.py
@@ -118,7 +118,7 @@ class RandomMatrixTest(tf.test.TestCase):
   def test_random_unitary_matrix(self):
     """Checks that returned matrix is unitary.
 
-    Unitary matrices are there own inverse.  See Wikipedia,
+    Unitary matrices are their own inverse.  See Wikipedia,
     https://en.wikipedia.org/wiki/Unitary_matrix
     """
     for n in self.num_qubits_list:
@@ -133,8 +133,8 @@ class RandomMatrixTest(tf.test.TestCase):
   def test_random_mixed_density_operator(self):
     """Checks return is a density matrix, and its eigenvalues match probs return
 
-    Density matrices are positive operators with trace one.  See Wikipedia,
-    https://en.wikipedia.org/wiki/Density_matrix
+    Density matrices are positive-semidefinite operators with trace one.
+    See Wikipedia, https://en.wikipedia.org/wiki/Density_matrix
     """
     for n in self.num_qubits_list:
       expected_dim = 2**n


### PR DESCRIPTION
Resolves #219 

Implements utilities for generating random Hermitian, unitary, and density matrices.  Replaces the versions that relied on scipy, which were causing CI breaks.

Also removes some unused and untested functions from `test_util.py` (`get_random_pauli_sum`, `generate_pure_random_density_operator`, `generate_mixed_random_density_operator_pair`, and `stable_classical_entropy`)