### PR TITLE
Update log partition

### DIFF
--- a/qhbmlib/inference/ebm.py
+++ b/qhbmlib/inference/ebm.py
@@ -343,7 +343,7 @@ class EnergyInference(EnergyInferenceBase):
     return _inner_log_partition()
 
   def _log_partition_forward_pass(self):
-    """Returns approximation to the log partition function.
+    r"""Returns approximation to the log partition function.
 
     The calculation uses the uniform distribution to approximate the
     partition function using Monte Carlo integration.  See section 11.2 of [1]

--- a/qhbmlib/inference/ebm.py
+++ b/qhbmlib/inference/ebm.py
@@ -357,7 +357,7 @@ class EnergyInference(EnergyInferenceBase):
     $$
     where $x$ ranges over the domain of $E$.  We do not want to compute this sum
     directly because it is over a set exponentially large in the number of bits.
-    Instead, we can use Monte Carlo integration.  To support this consider
+    Instead, we can use Monte Carlo integration.  To support this, consider
     rewriting the sum as an expectation value with respect to the uniform
     distribution $u(x)$:
     $$
@@ -377,7 +377,7 @@ class EnergyInference(EnergyInferenceBase):
     $$
     \log Z
       \approx \log \left(\frac{1}{N_s}\sum_{i=1}^{N_s} 2^n e^{-E(x_i)}\right)
-      = n \log 2 - \log N_s + \log \sum_{i=1}^{N_s}  e^{-E(x_i)}
+      = n \log 2 - \log N_s + \log \sum_{i=1}^{N_s}  e^{-E(x_i)}.
     $$
 
     #### References
@@ -389,9 +389,8 @@ class EnergyInference(EnergyInferenceBase):
     n_s = self.num_expectation_samples
     # Sample from the uniform distribution
     samples = tfp.distributions.Bernoulli(logits=tf.zeros([n])).sample(n_s)
-
     energies = self.energy(samples)
-    return n * tf.math.log(2.0) - tf.math.log(n_s) + tf.math.reduce_logsumexp(
+    return n * tf.math.log(2.0) - tf.math.log(tf.cast(n_s, tf.float32)) + tf.math.reduce_logsumexp(
         -1.0 * energies)
 
   def _log_partition_grad_generator(self):

--- a/qhbmlib/inference/ebm.py
+++ b/qhbmlib/inference/ebm.py
@@ -358,11 +358,11 @@ class EnergyInference(EnergyInferenceBase):
     # Sample from the uniform distribution
     samples = tfp.distributions.Bernoulli(
         logits=tf.zeros([self.energy.num_bits])).sample(
-        self.num_expectation_samples)
+            self.num_expectation_samples)
     # gamma tilde
     unnormalized_probabilities = tf.math.exp(-1.0 * self.energy(samples))
     # Equation 11.39
-    weights = unnormalized_probabilities * 2 ** self.energy.num_bits
+    weights = unnormalized_probabilities * 2**self.energy.num_bits
     return tf.math.log(
         tf.math.reduce_sum(weights) / tf.cast(tf.shape(samples)[0], tf.float32))
 
@@ -383,9 +383,7 @@ class EnergyInference(EnergyInferenceBase):
           unconnected_gradients=tf.UnconnectedGradients.ZERO)
       average_jacobians = tf.nest.map_structure(
           lambda j: utils.weighted_average(counts, j), unique_jacobians)
-      return tuple(), [
-          upstream * (-1.0 * aj) for aj in average_jacobians
-      ]
+      return tuple(), [upstream * (-1.0 * aj) for aj in average_jacobians]
 
     return grad_fn
 

--- a/qhbmlib/inference/ebm.py
+++ b/qhbmlib/inference/ebm.py
@@ -363,20 +363,20 @@ class EnergyInference(EnergyInferenceBase):
     $$
     Z = \sum_x e^{-E(x)}
       = \sum_x u(x) 2^n e^{-E(x)}
-      = \mathbb{E}\left[2^n e^{-E(\cdot)}\right],
+      = 2^n \mathbb{E}\left[e^{-E(\cdot)}\right],
     $$
     where $n$ is the number of bits in each uniform sample.  Now draw $N_s$
     samples from the uniform distribution.  Then we can approximate the
     expectation value as (equation 11.2)
     $$
-    \mathbb{E}\left[2^n e^{-E(\cdot)}\right]
-      \approx\frac{1}{N_s}\sum_{i=1}^{N_s} 2^n e^{-E(x_i)}.
+    2^n \mathbb{E}\left[e^{-E(\cdot)}\right]
+      \approx\frac{2^n}{N_s}\sum_{i=1}^{N_s} e^{-E(x_i)}.
     $$
     Next, what we are really interested in is the logarithm of the partition
     function.  Then we have
     $$
     \log Z
-      \approx \log \left(\frac{1}{N_s}\sum_{i=1}^{N_s} 2^n e^{-E(x_i)}\right)
+      \approx \log \left(\frac{2^n}{N_s}\sum_{i=1}^{N_s} e^{-E(x_i)}\right)
       = n \log 2 - \log N_s + \log \sum_{i=1}^{N_s}  e^{-E(x_i)}.
     $$
 

--- a/qhbmlib/inference/ebm.py
+++ b/qhbmlib/inference/ebm.py
@@ -390,8 +390,8 @@ class EnergyInference(EnergyInferenceBase):
     # Sample from the uniform distribution
     samples = tfp.distributions.Bernoulli(logits=tf.zeros([n])).sample(n_s)
     energies = self.energy(samples)
-    return n * tf.math.log(2.0) - tf.math.log(tf.cast(n_s, tf.float32)) + tf.math.reduce_logsumexp(
-        -1.0 * energies)
+    return n * tf.math.log(2.0) - tf.math.log(tf.cast(
+        n_s, tf.float32)) + tf.math.reduce_logsumexp(-1.0 * energies)
 
   def _log_partition_grad_generator(self):
     """Returns default estimator for the log partition function derivative."""


### PR DESCRIPTION
Two updates:

- Change to unbiased importance sampling estimator, easier to defend than the biased sampler I had been using
- Remove the dependence of the log partition function derivative on the `expectation` method.  This is so that in #225 I can restrict `expectation` to accept only tensor valued functions instead of allowing structure valued functions.